### PR TITLE
Add configure option to force version resources

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,5 +1,5 @@
 # EupsPkg config file. Sourced by 'eupspkg'
 
 TAP_PACKAGE=1
-CONFIGURE_OPTIONS="--prefix=$PREFIX"
+CONFIGURE_OPTIONS="--prefix=$PREFIX --enable-versioned-symbols"
 


### PR DESCRIPTION
Default configure+make behavior on Ubuntu/Debian platforms results
in a lib with no embedded version resource; this breaks cmake for
packages which depend on this package.

Added a configure option to force generation of version resources
(cribbed from the Debian libcurl package script).